### PR TITLE
Ensure extracted files are written to the path, not the filename

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -492,6 +492,8 @@ impl File {
 
         self.read(archive, &mut buf)?;
 
+        fs::create_dir_all(path.as_ref().parent().unwrap())?;
+
         if path.as_ref().exists() {
             return Err(Error::new(ErrorKind::AlreadyExists, "File already exists"));
         }

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -499,7 +499,7 @@ impl File {
         let mut file = fs::OpenOptions::new()
             .create(true)
             .write(true)
-            .open(&self.name)
+            .open(&path)
             .unwrap();
 
         file.write(&buf)


### PR DESCRIPTION
Looks like the extract function was always writing to the current working directory and using the file's name, not the requested output path.