### PR TITLE
[PR] Upgrade Compression Libraries and Add Memory Loading Function for MPQ Support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ doc = false
 [dependencies]
 adler32 = "1.0"
 byteorder = "1.0"
-bzip2 = "0.3"
-flate2 = "0.2"
+bzip2-rs = "0.1.2"
+flate2 = "1.0.27"
 getopts = "0.2"
 implode = "0.1"

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -4,8 +4,8 @@ use adler32::RollingAdler32;
 use byteorder::{ByteOrder, LittleEndian};
 use std::fmt;
 use std::fs;
-use std::io::{prelude::*, Cursor};
 use std::io::SeekFrom;
+use std::io::{prelude::*, Cursor};
 use std::io::{Error, ErrorKind};
 use std::mem;
 use std::path::Path;
@@ -134,7 +134,7 @@ impl Block {
 }
 
 pub struct Archive {
-    file: Cursor<[u8; 32]>,
+    file: Cursor<Vec<u8>>,
     header: Header,
     user_data_header: Option<UserDataHeader>,
     hash_table: Vec<Hash>,
@@ -152,8 +152,7 @@ impl Archive {
         Self::load(buf)
     }
 
-    pub fn load(mut buf: Vec<u8>) -> Result<Archive, Error> 
-    {
+    pub fn load(buf: Vec<u8>) -> Result<Archive, Error> {
         let mut buffer: [u8; HEADER_SIZE_V1] = [0; HEADER_SIZE_V1];
         let mut offset: u64 = 0;
         let mut user_data_header = None;
@@ -282,7 +281,7 @@ impl Archive {
                 if block.flags & FILE_SINGLE_UNIT == 0 {
                     // FixMe: handle empty files, packed and unpacked size should be 0
 
-                    if block.unpacked_size == 0  || self.sector_size == 0 {
+                    if block.unpacked_size == 0 || self.sector_size == 0 {
                         return Err(Error::new(ErrorKind::UnexpectedEof, filename));
                     }
 
@@ -472,7 +471,7 @@ impl File {
     fn read_single_unit_file(
         &self,
         buff_size: usize,
-        file: &mut Cursor<[u8; 32]>,
+        file: &mut Cursor<Vec<u8>>,
         offset: u64,
         out_buf: &mut [u8],
     ) -> Result<usize, Error> {

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -1,7 +1,7 @@
 use crate::archive::Archive;
+use std::collections::HashSet;
 use std::io::{Error, ErrorKind};
 use std::path::Path;
-use std::collections::HashSet;
 
 #[derive(Default)]
 pub struct Chain {
@@ -92,7 +92,7 @@ impl Chain {
         for archive in &mut self.chain.iter_mut() {
             let file = match archive.open_file(filename) {
                 Ok(f) => f,
-                Err(_) => continue
+                Err(_) => continue,
             };
 
             return file.extract(archive, path);

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -2,7 +2,7 @@ use bzip2_rs as bzip2;
 use flate2;
 use implode::exploder::Exploder;
 use implode::symbol::DEFAULT_CODE_TABLE;
-use std::io::{self, Error, ErrorKind, Read};
+use std::io::{self, Error, ErrorKind};
 
 const COMPRESSION_HUFFMAN: u8 = 0x01;
 const COMPRESSION_ZLIB: u8 = 0x02;

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -1,8 +1,8 @@
-use bzip2;
+use bzip2_rs as bzip2;
 use flate2;
 use implode::exploder::Exploder;
 use implode::symbol::DEFAULT_CODE_TABLE;
-use std::io::{Error, ErrorKind};
+use std::io::{self, Error, ErrorKind, Read};
 
 const COMPRESSION_HUFFMAN: u8 = 0x01;
 const COMPRESSION_ZLIB: u8 = 0x02;
@@ -17,20 +17,16 @@ pub fn decompress(data: &mut [u8], out: &mut [u8]) -> Result<usize, Error> {
     let compression_type = data[0];
 
     if compression_type & COMPRESSION_BZIP2 != 0 {
-        let mut decompress = bzip2::Decompress::new(true);
-
-        match decompress.decompress(&data[1..], out) {
-            Ok(_) => {}
-            Err(e) => return Err(Error::new(ErrorKind::Other, e)),
-        }
-
-        return Ok(decompress.total_out() as usize);
+        let mut ouput = io::Cursor::new(out);
+        let mut reader = bzip2::DecoderReader::new(&data[1..]);
+        io::copy(&mut reader, &mut ouput)?;
+        return Ok(ouput.position() as usize);
     }
 
     if compression_type & COMPRESSION_ZLIB != 0 {
         let mut zlib = flate2::Decompress::new(true);
 
-        match zlib.decompress(&data[1..], out, flate2::Flush::None) {
+        match zlib.decompress(&data[1..], out, flate2::FlushDecompress::None) {
             Ok(_) => {}
             Err(e) => return Err(Error::new(ErrorKind::Other, e)),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ fn main() {
 
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
-        Err(f) => panic!(f.to_string()),
+        Err(f) => panic!("{}", f.to_string()),
     };
 
     if matches.opt_present("version") {


### PR DESCRIPTION
Dear mpq-rust project maintainer,

I would like to submit a PR to introduce some important features and improvements. Here are the main modifications I plan to make:

1. Upgrade the versions of compression-related crates to enable compiling wasm artifacts using pure Rust libraries. The specific changes include:
    - Upgrading the `flate2` crate to version 1.0 to ensure compatibility with the latest Rust versions.
    - Replacing the `bzip2` crate with `bzip2-rs`, a pure Rust implementation of the bzip2 decompression algorithm.

2. Add a public function `load` that takes a `Vec<u8>` buffer as input and returns a `Result<Archive, Error>`. The purpose of this function is to load an MPQ file into memory for further processing. This function will provide a convenient way to handle MPQ files without the need to save them to disk first.

I believe these modifications will bring significant benefits to the project, including improved compatibility and a more user-friendly approach. I have implemented and tested these changes to ensure their proper functioning.

Thank you very much for your time and consideration. I look forward to your response and the opportunity to contribute valuable enhancements to the mpq-rust project.

Best regards, magicwenli